### PR TITLE
Make sure `transferred_to_hpc` gets set

### DIFF
--- a/dataflow_transfer/dataflow_transfer.py
+++ b/dataflow_transfer/dataflow_transfer.py
@@ -22,8 +22,9 @@ def process_run(run_dir, sequencer, config):
     run.confirm_run_type()
 
     ## Transfer already completed. Do nothing.
-    if run.final_sync_successful:
-        # Removing the exit code file lets the run retry transfer
+    if run.final_sync_successful and run.has_status("transferred_to_hpc"):
+        # Check transfer success both in statusdb and via exit code file
+        # To restart transfer, remove the exit code file
         logger.info(f"Transfer of {run_dir} is finished. No action needed.")
         return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ ignore = [
 
 [project]
 name = "dataflow_transfer"
-version = "1.0.3"
+version = "1.0.4"
 description = "Script for transferring sequencing data from sequencers to storage"
 authors = [
     { name = "Sara Sjunnebo", email = "sara.sjunnebo@scilifelab.se" },


### PR DESCRIPTION
In the fist check, look both for the final exit status file _and_ `transferred_to_hpc` status. Otherwise the final `if` that sets `transferred_to_hpc` never gets executed.