### PR TITLE
Set FCID to whatever is scanned during sequencing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ log:
 
 run_one_path: /usr/bin/run-one
 
-metadata_archive: /path/to/metadata/archive
-
 transfer_details:
   user: username
   host: remote.host.com
@@ -99,6 +97,7 @@ sequencers:
   NovaSeqXPlus:
     sequencing_path: /sequencing/NovaSeqXPlus
     remote_destination: /Illumina/NovaSeqXPlus
+    metadata_archive: /path/to/metadata/archive/NovaSeqXPlus_data
     metadata_for_statusdb:
       - RunInfo.xml
       - RunParameters.xml
@@ -150,6 +149,7 @@ Run status is tracked in CouchDB with events including:
 - Remote storage is accessible via rsync over SSH
 - CouchDB is accessible and the database exists
 - Metadata files (e.g., RunInfo.xml) are present in run directories for status database updates and sync to metadata archive location
+- The flowcell ID is set to correspond to the ID that is scanned with a barcode scanner during sequencing setup in the lab
 
 ### Status Files
 

--- a/dataflow_transfer/run_classes/element_runs.py
+++ b/dataflow_transfer/run_classes/element_runs.py
@@ -19,7 +19,7 @@ class AVITIRun(ElementRun):
 
     def __init__(self, run_dir, configuration):
         self.run_id_format = (
-            r"^\d{8}_AV\d{6}_(A|BP)\d{10}$"  # 20251007_AV242106_A2507535225
+            r"^\d{8}_AV\d{6}_(A|B)\d{10}$"  # 20251007_AV242106_A2507535225
         )
         super().__init__(run_dir, configuration)
         self.flowcell_id = self.run_id.split("_")[-1][1:]  # 2507535225

--- a/dataflow_transfer/run_classes/element_runs.py
+++ b/dataflow_transfer/run_classes/element_runs.py
@@ -9,9 +9,6 @@ class ElementRun(Run):
     def __init__(self, run_dir, configuration):
         super().__init__(run_dir, configuration)
         self.final_file = "RunUploaded.json"
-        self.flowcell_id = self.run_id.split("_")[
-            -1
-        ]  # This is true for all except Teton runs
 
 
 @register_run_class
@@ -24,4 +21,8 @@ class AVITIRun(ElementRun):
         self.run_id_format = (
             r"^\d{8}_AV\d{6}_(A|BP)\d{10}$"  # 20251007_AV242106_A2507535225
         )
+        self.flowcell_id = self.run_id.split("_")[-1][1:]  # 2507535225
         super().__init__(run_dir, configuration)
+
+
+# TODO: Add Teton run class

--- a/dataflow_transfer/run_classes/element_runs.py
+++ b/dataflow_transfer/run_classes/element_runs.py
@@ -21,8 +21,8 @@ class AVITIRun(ElementRun):
         self.run_id_format = (
             r"^\d{8}_AV\d{6}_(A|BP)\d{10}$"  # 20251007_AV242106_A2507535225
         )
-        self.flowcell_id = self.run_id.split("_")[-1][1:]  # 2507535225
         super().__init__(run_dir, configuration)
+        self.flowcell_id = self.run_id.split("_")[-1][1:]  # 2507535225
 
 
 # TODO: Add Teton run class

--- a/dataflow_transfer/run_classes/generic_runs.py
+++ b/dataflow_transfer/run_classes/generic_runs.py
@@ -25,8 +25,7 @@ class Run:
             self.run_dir, ".metadata_rsync_exitcode"
         )
         self.metadata_destination = os.path.join(
-            self.configuration.get("metadata_archive"),
-            getattr(self, "run_type", None),
+            self.sequencer_config.get("metadata_archive"),
             self.run_id,
         )
         self.final_rsync_exitcode_file = os.path.join(

--- a/dataflow_transfer/run_classes/illumina_runs.py
+++ b/dataflow_transfer/run_classes/illumina_runs.py
@@ -9,7 +9,6 @@ class IlluminaRun(Run):
     def __init__(self, run_dir, configuration):
         super().__init__(run_dir, configuration)
         self.final_file = "CopyComplete.txt"
-        self.flowcell_id = self.run_id.split("_")[-1]
 
 
 @register_run_class
@@ -22,6 +21,7 @@ class NovaSeqXPlusRun(IlluminaRun):
         self.run_id_format = (
             r"^\d{8}_[A-Z0-9]+_\d{4}_[A-Z0-9]+$"  # 20251010_LH00202_0284_B22CVHTLT1
         )
+        self.flowcell_id = self.run_id.split("_")[-1][1:]  # 22CVHTLT1
         super().__init__(run_dir, configuration)
 
 
@@ -35,6 +35,7 @@ class NextSeqRun(IlluminaRun):
         self.run_id_format = (
             r"^\d{6}_[A-Z0-9]+_\d{3}_[A-Z0-9]+$"  # 251015_VH00203_572_AAHFHCCM5
         )
+        self.flowcell_id = self.run_id.split("_")[-1]  # AAHFHCCM5
         super().__init__(run_dir, configuration)
 
 
@@ -48,6 +49,7 @@ class MiSeqRun(IlluminaRun):
         self.run_id_format = (
             r"^\d{6}_[A-Z0-9]+_\d{4}_[A-Z0-9\-]+$"  # 251015_M01548_0646_000000000-M6D7K
         )
+        self.flowcell_id = self.run_id.split("_")[-1]  # 000000000-M6D7K
         super().__init__(run_dir, configuration)
 
 
@@ -59,4 +61,5 @@ class MiSeqi100Run(IlluminaRun):
 
     def __init__(self, run_dir, configuration):
         self.run_id_format = r"^\d{8}_[A-Z0-9]+_\d{4}_[A-Z0-9]{10}-SC3$"  # 20260128_SH01140_0002_ASC2150561-SC3
+        self.flowcell_id = self.run_id.split("_")[-1][1:]  # SC2150561-SC3
         super().__init__(run_dir, configuration)

--- a/dataflow_transfer/run_classes/illumina_runs.py
+++ b/dataflow_transfer/run_classes/illumina_runs.py
@@ -9,6 +9,7 @@ class IlluminaRun(Run):
     def __init__(self, run_dir, configuration):
         super().__init__(run_dir, configuration)
         self.final_file = "CopyComplete.txt"
+        self.flowcell_id = self.run_id.split("_")[-1]
 
 
 @register_run_class
@@ -36,7 +37,6 @@ class NextSeqRun(IlluminaRun):
             r"^\d{6}_[A-Z0-9]+_\d{3}_[A-Z0-9]+$"  # 251015_VH00203_572_AAHFHCCM5
         )
         super().__init__(run_dir, configuration)
-        self.flowcell_id = self.run_id.split("_")[-1]  # AAHFHCCM5
 
 
 @register_run_class
@@ -50,7 +50,6 @@ class MiSeqRun(IlluminaRun):
             r"^\d{6}_[A-Z0-9]+_\d{4}_[A-Z0-9\-]+$"  # 251015_M01548_0646_000000000-M6D7K
         )
         super().__init__(run_dir, configuration)
-        self.flowcell_id = self.run_id.split("_")[-1]  # 000000000-M6D7K
 
 
 @register_run_class

--- a/dataflow_transfer/run_classes/illumina_runs.py
+++ b/dataflow_transfer/run_classes/illumina_runs.py
@@ -21,8 +21,8 @@ class NovaSeqXPlusRun(IlluminaRun):
         self.run_id_format = (
             r"^\d{8}_[A-Z0-9]+_\d{4}_[A-Z0-9]+$"  # 20251010_LH00202_0284_B22CVHTLT1
         )
-        self.flowcell_id = self.run_id.split("_")[-1][1:]  # 22CVHTLT1
         super().__init__(run_dir, configuration)
+        self.flowcell_id = self.run_id.split("_")[-1][1:]  # 22CVHTLT1
 
 
 @register_run_class
@@ -35,8 +35,8 @@ class NextSeqRun(IlluminaRun):
         self.run_id_format = (
             r"^\d{6}_[A-Z0-9]+_\d{3}_[A-Z0-9]+$"  # 251015_VH00203_572_AAHFHCCM5
         )
-        self.flowcell_id = self.run_id.split("_")[-1]  # AAHFHCCM5
         super().__init__(run_dir, configuration)
+        self.flowcell_id = self.run_id.split("_")[-1]  # AAHFHCCM5
 
 
 @register_run_class
@@ -49,8 +49,8 @@ class MiSeqRun(IlluminaRun):
         self.run_id_format = (
             r"^\d{6}_[A-Z0-9]+_\d{4}_[A-Z0-9\-]+$"  # 251015_M01548_0646_000000000-M6D7K
         )
-        self.flowcell_id = self.run_id.split("_")[-1]  # 000000000-M6D7K
         super().__init__(run_dir, configuration)
+        self.flowcell_id = self.run_id.split("_")[-1]  # 000000000-M6D7K
 
 
 @register_run_class
@@ -61,5 +61,5 @@ class MiSeqi100Run(IlluminaRun):
 
     def __init__(self, run_dir, configuration):
         self.run_id_format = r"^\d{8}_[A-Z0-9]+_\d{4}_[A-Z0-9]{10}-SC3$"  # 20260128_SH01140_0002_ASC2150561-SC3
-        self.flowcell_id = self.run_id.split("_")[-1][1:]  # SC2150561-SC3
         super().__init__(run_dir, configuration)
+        self.flowcell_id = self.run_id.split("_")[-1][1:]  # SC2150561-SC3

--- a/dataflow_transfer/tests/test_run_classes.py
+++ b/dataflow_transfer/tests/test_run_classes.py
@@ -12,7 +12,6 @@ def novaseqxplus_testobj(tmp_path):
     config = {
         "log": {"file": "test.log"},
         "transfer_details": {"user": "testuser", "host": "testhost"},
-        "metadata_archive": "/data/metadata_archive",
         "statusdb": {
             "username": "dbuser",
             "password": "dbpass",
@@ -23,6 +22,7 @@ def novaseqxplus_testobj(tmp_path):
             "NovaSeqXPlus": {
                 "remote_destination": "/data/NovaSeqXPlus",
                 "metadata_for_statusdb": ["RunInfo.xml", "RunParameters.xml"],
+                "metadata_archive": "/data/metadata_archive/NovaSeqXPlus",
                 "ignore_folders": ["nosync"],
                 "remote_rsync_options": ["--chmod=Dg+s,g+rw"],
                 "metadata_rsync_options": [
@@ -44,7 +44,6 @@ def nextseq_testobj(tmp_path):
     config = {
         "log": {"file": "test.log"},
         "transfer_details": {"user": "testuser", "host": "testhost"},
-        "metadata_archive": "/data/metadata_archive",
         "statusdb": {
             "username": "dbuser",
             "password": "dbpass",
@@ -55,6 +54,7 @@ def nextseq_testobj(tmp_path):
             "NextSeq": {
                 "remote_destination": "/data/NextSeq",
                 "metadata_for_statusdb": ["RunInfo.xml", "RunParameters.xml"],
+                "metadata_archive": "/data/metadata_archive/NextSeq",
                 "ignore_folders": ["nosync"],
                 "remote_rsync_options": ["--chmod=Dg+s,g+rw"],
                 "metadata_rsync_options": [
@@ -76,7 +76,6 @@ def miseqseq_testobj(tmp_path):
     config = {
         "log": {"file": "test.log"},
         "transfer_details": {"user": "testuser", "host": "testhost"},
-        "metadata_archive": "/data/metadata_archive",
         "statusdb": {
             "username": "dbuser",
             "password": "dbpass",
@@ -87,6 +86,7 @@ def miseqseq_testobj(tmp_path):
             "MiSeq": {
                 "remote_destination": "/data/MiSeq",
                 "metadata_for_statusdb": ["RunInfo.xml", "RunParameters.xml"],
+                "metadata_archive": "/data/metadata_archive/MiSeq",
                 "ignore_folders": ["nosync"],
                 "remote_rsync_options": ["--chmod=Dg+s,g+rw"],
                 "metadata_rsync_options": [
@@ -108,7 +108,6 @@ def miseqseqi100_testobj(tmp_path):
     config = {
         "log": {"file": "test.log"},
         "transfer_details": {"user": "testuser", "host": "testhost"},
-        "metadata_archive": "/data/metadata_archive",
         "statusdb": {
             "username": "dbuser",
             "password": "dbpass",
@@ -119,6 +118,7 @@ def miseqseqi100_testobj(tmp_path):
             "MiSeqi100": {
                 "remote_destination": "/data/MiSeqi100",
                 "metadata_for_statusdb": ["RunInfo.xml", "RunParameters.xml"],
+                "metadata_archive": "/data/metadata_archive/MiSeqi100",
                 "ignore_folders": ["nosync"],
                 "remote_rsync_options": ["--chmod=Dg+s,g+rw"],
                 "metadata_rsync_options": [

--- a/dataflow_transfer/tests/test_run_classes.py
+++ b/dataflow_transfer/tests/test_run_classes.py
@@ -170,6 +170,20 @@ def test_confirm_run_type(run_fixture, expected_run_type, request):
 
 
 @pytest.mark.parametrize(
+    "run_fixture, expected_flowcell",
+    [
+        ("novaseqxplus_testobj", "22CVHTLT1"),
+        ("nextseq_testobj", "AAHFHCCM5"),
+        ("miseqseq_testobj", "000000000-M6D7K"),
+        ("miseqseqi100_testobj", "SC2150561-SC3"),
+    ],
+)
+def test_flowcell_id_is_computed(run_fixture, expected_flowcell, request):
+    run_obj = request.getfixturevalue(run_fixture)
+    assert run_obj.flowcell_id == expected_flowcell
+
+
+@pytest.mark.parametrize(
     "run_fixture",
     [
         "novaseqxplus_testobj",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ ignore = [
 
 [project]
 name = "dataflow_transfer"
-version = "1.1.1"
+version = "1.1.2"
 description = "Script for transferring sequencing data from sequencers to storage"
 authors = [
     { name = "Sara Sjunnebo", email = "sara.sjunnebo@scilifelab.se" },


### PR DESCRIPTION
* Set FCID to whatever is scanned during sequencing setup (i.e. remove the side letter for MiSeq100, NovaSeqXPlus and Aviti)
* Specify the path to the metadata archive for each sequencer in the config file